### PR TITLE
JSON outputs for FiberSection creation command

### DIFF
--- a/SRC/material/section/FiberSection2d.cpp
+++ b/SRC/material/section/FiberSection2d.cpp
@@ -917,7 +917,15 @@ FiberSection2d::Print(OPS_Stream &s, int flag)
       else
 	s << "}\n";	
     }
-    s << "\t\t\t]}";
+    s << "\t\t\t]";
+    FiberSectionRepr *sectionRepres = (FiberSectionRepr *)OPS_getSectionRepres(this->getTag());
+    if (sectionRepres == 0) 
+   {
+	   s<<'}';
+   } else {
+	   sectionRepres->Print(s,flag);
+	   s<<'}';
+   }
   }
 }
 

--- a/SRC/material/section/FiberSection2d.h
+++ b/SRC/material/section/FiberSection2d.h
@@ -36,6 +36,7 @@
 #include <SectionForceDeformation.h>
 #include <Vector.h>
 #include <Matrix.h>
+#include <FiberSectionRepr.h>
 
 class UniaxialMaterial;
 class Fiber;

--- a/SRC/material/section/FiberSection3d.cpp
+++ b/SRC/material/section/FiberSection3d.cpp
@@ -1149,7 +1149,15 @@ FiberSection3d::Print(OPS_Stream &s, int flag)
 		  else
 			  s << "}\n";
 	  }
-	  s << "\t\t\t]}";
+	  s << "\t\t\t]";
+	  FiberSectionRepr *sectionRepres = (FiberSectionRepr *)OPS_getSectionRepres(this->getTag());
+		if (sectionRepres == 0) 
+		{
+		   s<<'}';
+		} else {
+		   sectionRepres->Print(s,flag);
+		   s<<'}';
+		}
   }
 }
 

--- a/SRC/material/section/FiberSection3d.h
+++ b/SRC/material/section/FiberSection3d.h
@@ -36,6 +36,7 @@
 #include <SectionForceDeformation.h>
 #include <Vector.h>
 #include <Matrix.h>
+#include <FiberSectionRepr.h>
 
 class UniaxialMaterial;
 class Fiber;

--- a/SRC/material/section/fiber/UniaxialFiber2d.cpp
+++ b/SRC/material/section/fiber/UniaxialFiber2d.cpp
@@ -348,10 +348,16 @@ UniaxialFiber2d::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &
 
 void UniaxialFiber2d::Print(OPS_Stream &s, int flag)
 {
+	if (flag == OPS_PRINT_PRINTMODEL_SECTION || flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
   s << "\nUniaxialFiber2d, tag: " << this->getTag() << endln;
   s << "\tArea: " << area << endln; 
   s << "\tMatrix as: " << 1.0 << " " << y << endln; 
   s << "\tMaterial, tag: " << theMaterial->getTag() << endln;
+  }
+if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	 s << "\t\t\t\t{\"type\": \"fiber\", \"material\": "<<theMaterial->getTag()<<", ";
+	 s << "\"area\": "<<area<<", \"coord\": [" << y << ", 0.0]}";
+}
 }
 
 Response*

--- a/SRC/material/section/fiber/UniaxialFiber3d.cpp
+++ b/SRC/material/section/fiber/UniaxialFiber3d.cpp
@@ -360,10 +360,17 @@ UniaxialFiber3d::recvSelf(int commitTag, Channel &theChannel,
 
 void UniaxialFiber3d::Print(OPS_Stream &s, int flag)
 {
+if (flag == OPS_PRINT_PRINTMODEL_SECTION || flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
     s << "\nUniaxialFiber3d, tag: " << this->getTag() << endln;
     s << "\tArea: " << area << endln; 
     s << "\tMatrix as: " << 1.0 << " " << as[0] << " " << as[1] << endln; 
     s << "\tMaterial, tag: " << theMaterial->getTag() << endln;
+}
+if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	 s << "\t\t\t\t{\"type\": \"fiber\", \"material\": "<<theMaterial->getTag()<<", ";
+	 s << "\"area\": "<<area<<", \"coord\": [" << as[0] << ", "<<as[1]<<"]}";
+}
+
 }
 
 Response*

--- a/SRC/material/section/repres/patch/CircPatch.cpp
+++ b/SRC/material/section/repres/patch/CircPatch.cpp
@@ -233,6 +233,7 @@ CircPatch::getCopy (void) const
  
 void CircPatch::Print(OPS_Stream &s, int flag) const
 {
+	if (flag == OPS_PRINT_PRINTMODEL_SECTION || flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
    s << "\nPatch Type: CircPatch";
    s << "\nMaterial Id: " << matID;
    s << "\nNumber of subdivisions in the radial direction: " << nDivRad;
@@ -240,6 +241,14 @@ void CircPatch::Print(OPS_Stream &s, int flag) const
    s << "\nCenter Position: " << centerPosit;
    s << "\nInternal Radius: " << intRad << "\tExternal Radius: " << extRad;
    s << "\nInitial Angle: " << initAng << "\tFinal Angle: " << finalAng;
+}
+if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	 s << "\t\t\t\t{\"type\": \"circ\", \"material\": "<<matID<<", \"divisions\":[" << nDivRad << ","<< nDivCirc<<"], ";
+	 s << "\"center\": ["<<centerPosit(0)<<","<<centerPosit(1)<<"], ";
+	 s << "\"radii\": ["<<intRad<<", "<<extRad<<"],";
+	 s << "\"angles\": ["<<initAng<<", "<<finalAng<<"]";
+	 s <<"}";
+}
 }
 
 

--- a/SRC/material/section/repres/patch/QuadPatch.cpp
+++ b/SRC/material/section/repres/patch/QuadPatch.cpp
@@ -240,11 +240,22 @@ QuadPatch::getCopy (void) const
  
 void QuadPatch::Print(OPS_Stream &s, int flag) const
 {
+	if (flag == OPS_PRINT_PRINTMODEL_SECTION || flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
    s << "\nPatch Type: QuadPatch";
    s << "\nMaterial Id: " << matID;
    s << "\nNumber of subdivisions in the IJ direction: " << nDivIJ;
    s << "\nNumber of subdivisions in the JK direction: " << nDivJK;
    s << "\nVertex Coordinates: " << vertCoord;
+}
+if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	 s << "\t\t\t\t{\"type\": \"quad\", \"material\": "<<matID<<", \"divisions\":[" << nDivIJ << ","<< nDivJK<<"], ";
+	 s << "\"vertices\": [";
+	 s << "["<<vertCoord(0,0)<<","<<vertCoord(0,1)<<"], ";
+	 s << "["<<vertCoord(1,0)<<","<<vertCoord(1,1)<<"], ";
+	 s << "["<<vertCoord(2,0)<<","<<vertCoord(2,1)<<"], ";
+	 s << "["<<vertCoord(3,0)<<","<<vertCoord(3,1)<<"]";
+	 s <<"]}";
+}
 }
 
 

--- a/SRC/material/section/repres/reinfLayer/CircReinfLayer.cpp
+++ b/SRC/material/section/repres/reinfLayer/CircReinfLayer.cpp
@@ -225,6 +225,7 @@ CircReinfLayer::getCopy (void) const
 
 void CircReinfLayer::Print(OPS_Stream &s, int flag) const
 {
+	if (flag == OPS_PRINT_PRINTMODEL_SECTION || flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
    s << "\nReinforcing Layer type:  Circ";
    s << "\nMaterial ID: " << matID;
    s << "\nReinf. bar diameter: " << barDiam;
@@ -233,6 +234,14 @@ void CircReinfLayer::Print(OPS_Stream &s, int flag) const
    s << "\nArc Radius: " << arcRad;
    s << "\nInitial angle: " << initAng;
    s << "\nFinal angle: " << finalAng;
+}
+if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	 s << "\t\t\t\t{\"type\": \"layerCirc\", \"material\": "<<matID<<", "<<",\"area\": "<<area<<", ";
+	 s << "\"center\": ["<<centerPosit(0)<<","<<centerPosit(1)<<"], ";
+	 s << "\"radius\": "<<arcRad<<", ";
+	 s << "\"angles\": ["<<initAng<<", "<<finalAng<<"]";
+	 s <<"}";
+}
 }
 
 

--- a/SRC/material/section/repres/reinfLayer/StraightReinfLayer.cpp
+++ b/SRC/material/section/repres/reinfLayer/StraightReinfLayer.cpp
@@ -209,12 +209,20 @@ StraightReinfLayer::getCopy (void) const
 
 void StraightReinfLayer::Print(OPS_Stream &s, int flag) const
 {
+	if (flag == OPS_PRINT_PRINTMODEL_SECTION || flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
    s << "\nReinforcing Layer type:  Straight";
    s << "\nMaterial ID: " << matID;
    s << "\nReinf. bar diameter: " << barDiam;
    s << "\nReinf. bar area: " << area;
    s << "\nInitial Position: " << initPosit;
    s << "\nFinal Position: " << finalPosit;
+}
+if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	 s << "\t\t\t\t{\"type\": \"layerStraight\", \"material\": "<<matID<<", \"area\": "<<area<<", ";
+	 s << "\"initPos\": ["<<initPosit(0)<<","<<initPosit(1)<<"], ";
+	 s << "\"finlPos\": ["<<finalPosit(0)<<","<<finalPosit(1)<<"]";
+	 s <<"}";
+}   
 }
 
 

--- a/SRC/material/section/repres/section/FiberSectionRepr.cpp
+++ b/SRC/material/section/repres/section/FiberSectionRepr.cpp
@@ -283,6 +283,7 @@ FiberSectionRepr::getReinfLayers (void) const
 
 void FiberSectionRepr::Print(OPS_Stream &s, int flag)
 {
+	if (flag == OPS_PRINT_PRINTMODEL_SECTION || flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
 //   int i;
    
    s << "\nSection representation type: Fiber Section";
@@ -296,7 +297,32 @@ void FiberSectionRepr::Print(OPS_Stream &s, int flag)
    
 //   for (i=0; i<nReinfLayers; i++)
 //     s << "\nReinfLayer "<<i<<" :" << *reinfLayer[i];
-
+}
+if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	s<<",\"sectionRepr\": [\n";
+	for (int patchCtr=0;patchCtr<nPatches;patchCtr++) {
+		patch[patchCtr]->Print(s,flag);
+		if (patchCtr < nPatches-1)
+			s << ",\n";
+		else
+			s << "\n";	
+    }
+    for (int layerCtr=0;layerCtr<nReinfLayers;layerCtr++) {
+		reinfLayer[layerCtr]->Print(s,flag);
+		if (layerCtr < nReinfLayers-1)
+			s << ",\n";
+		else
+			s << "\n";	
+    }
+    for (int fibCtr=0;fibCtr<numFibers;fibCtr++) {
+		theFibers[fibCtr]->Print(s,flag);
+		if (fibCtr < numFibers-1)
+			s << ",\n";
+		else
+			s << "\n";	
+    }
+	s<<"\t\t\t]";
+}
 }
    
     


### PR DESCRIPTION
Add JSON output for FiberSectionRepr for FiberSection2d and FiberSection3d. Prints the internal representation of patch, layer and fiber commands used during fibersection creation.